### PR TITLE
Implement parsing for proxy protocol v2.

### DIFF
--- a/lib/server/header/haproxy-v2.js
+++ b/lib/server/header/haproxy-v2.js
@@ -50,6 +50,9 @@ function parseTLV(buffer, offset) {
   offset += 2;
   const value = buffer.subarray(offset, offset + length).toString();
   const typeName = TLV_TYPES[type];
+  if (!typeName) {
+    throw new Error(`Invalid TLV type: ${type.toString('hex')}`);
+  }
   return { type: typeName, length: length + 3, value };
 }
 
@@ -59,7 +62,11 @@ function parseProxyData(header, buffer) {
   };
 
   let offset = 0;
-  if (header.family === 0x01) {
+  if (header.family === 0x00) {
+    // No address information.
+    fields.remoteFamily = 'Unspecified';
+    offset += 2;
+  } else if (header.family === 0x01) {
     fields.remoteFamily = 'IPv4';
     fields.remoteAddress = decodeV4Address(buffer, offset);
     fields.localAddress = decodeV4Address(buffer, offset += 4);
@@ -73,9 +80,21 @@ function parseProxyData(header, buffer) {
     fields.remotePort = buffer.readUInt16BE(offset += 16);
     fields.localPort = buffer.readUInt16BE(offset += 2);
     offset += 2;
+  } else if (header.family === 0x03) {
+    fields.remoteFamily = 'UNIX';
+    fields.remoteAddress = buffer.read(offset, offset += 108).toString('binary');
+    fields.localAddress = buffer.read(offset, offset += 108).toString('binary');
+    fields.remotePort = null;
+    fields.localPort = null;
+    offset += 2;
+  } else {
+    throw new Error(`Invalid protocol family: ${header.family.toString('hex')}`);
   }
 
   while (offset < header.length) {
+    if (offset > header.length) {
+      throw new Error('Invalid length, exceeds buffer');
+    }
     const record = parseTLV(buffer, offset);
     fields.tlv.push(record);
     offset += record.length;
@@ -92,12 +111,11 @@ function parseProxyHeader(buffer) {
   // check magic:
   const preamble = buffer.subarray(0, 12);
   if (preamble.toString() !== MAGIC) {
-    throw new Error('Invalid proxy protocol preamble');
+    throw new Error(`Invalid proxy protocol preamble: ${preable.toString('hex')}`);
   }
 
   const famProt = buffer.readUInt8(13);
   fields.length = buffer.readUInt16BE(14);
-
   fields.family = (famProt & 0xf0) >> 4;
   fields.protocol = famProt & 0x0f;
 

--- a/lib/server/header/haproxy-v2.js
+++ b/lib/server/header/haproxy-v2.js
@@ -65,6 +65,10 @@ function parseProxyData(header, buffer) {
   if (header.family === 0x00) {
     // No address information.
     fields.remoteFamily = 'Unspecified';
+    fields.remoteAddress = null;
+    fields.localAddress = null;
+    fields.remotePort = null;
+    fields.localPort = null;
     offset += 2;
   } else if (header.family === 0x01) {
     fields.remoteFamily = 'IPv4';

--- a/lib/server/header/index.js
+++ b/lib/server/header/index.js
@@ -9,6 +9,8 @@
 
 var proxiedSocket = require('./proxied-socket');
 var haproxy = require('./haproxy');
+var proxyV2 = require('./proxy-v2');
 
 exports.proxiedSocket = proxiedSocket;
 exports.haproxy = haproxy;
+exports.proxyV2 = proxyV2;

--- a/lib/server/header/index.js
+++ b/lib/server/header/index.js
@@ -9,8 +9,8 @@
 
 var proxiedSocket = require('./proxied-socket');
 var haproxy = require('./haproxy');
-var proxyV2 = require('./proxy-v2');
+var haproxyV2 = require('./haproxy-v2');
 
 exports.proxiedSocket = proxiedSocket;
 exports.haproxy = haproxy;
-exports.proxyV2 = proxyV2;
+exports.haproxyV2 = haproxyV2;

--- a/lib/server/header/proxy-v2.js
+++ b/lib/server/header/proxy-v2.js
@@ -1,0 +1,135 @@
+/*jslint node: true, nomen: true, es5: true */
+/**
+ * Developed By:
+ * - Ben Timby (GitHub - btimby) ben.timby.com
+ * - Carlo Bernaschina (GitHub - B3rn475) www.bernaschina.com
+ *
+ * Distributed under the MIT Licence
+ */
+"use strict";
+
+const MAGIC = '\r\n\r\n\x00\r\nQUIT\n';
+const TLV_TYPES = {
+    0x01: 'ALPN',
+    0x02: 'AUTHORITY',
+    0x03: 'CRC32C',
+    0x04: 'NOOP',
+    0x05: 'UNIQUE_ID',
+    0x020: 'SSL',
+    0x021: 'SSL_VERSION',
+    0x022: 'SSL_CN',
+    0x023: 'SSL_CIPHER',
+    0x024: 'SSL_SIG_ALG',
+    0x025: 'SSL_KEY_ALG',
+    0x030: 'NETNS',
+}
+
+function decodeV4Address(buf, offset) {
+  let i;
+  const address = new Array(4);
+  for (i = 0; i < 4; i++) {
+    address[i] = Number(buf[offset + i]).toString();
+  }
+
+  return address.join('.');
+}
+
+function decodeV6Address(buf, offset) {
+  let i;
+  const address = new Array(8);
+  for (i = 0; i < 8; i++) {
+    address[i] = Number(buf.readUInt16BE(offset + i * 2, true)).toString(16);
+  }
+
+  return address.join(':').replace(/:(?:0:)+/, '::');
+}
+
+function parseTLV(buffer, offset) {
+  const type = buffer.readUInt8(offset);
+  const length = buffer.readUInt16BE(offset++);
+  offset += 2;
+  const value = buffer.subarray(offset, offset + length).toString();
+  const typeName = TLV_TYPES[type];
+  return { type: typeName, length: length + 2, value };
+}
+
+function parseProxyData(header, buffer) {
+  const fields = {
+    tlv: [],
+  };
+
+  let offset = 0;
+  if (header.family === 0x01) {
+    fields.remoteFamily = 'IPv4';
+    fields.remoteAddress = decodeV4Address(buffer, offset);
+    fields.localAddress = decodeV4Address(buffer, offset += 4);
+    fields.remotePort = buffer.readUInt16BE(offset += 4);
+    fields.localPort = buffer.readUInt16BE(offset += 2);
+    offset += 2;
+  } else if (header.family === 0x02) {
+    fields.remoteFamily = 'IPv6';
+    fields.remoteAddress = decodeV6Address(buffer, offset);
+    fields.localAddress = decodeV6Address(buffer, offset += 16);
+    fields.remotePort = buffer.readUInt16BE(offset += 16);
+    fields.localPort = buffer.readUInt16BE(offset += 2);
+    offset += 2;
+  }
+
+  while (offset < header.length - 1) {
+    const record = parseTLV(buffer, offset);
+    fields.tlv.push(record);
+    offset += record.length;
+  }
+
+  fields.length = offset;
+
+  return fields;
+}
+
+function parseProxyHeader(buffer) {
+  const fields = {};
+
+  // check magic:
+  const preamble = buffer.subarray(0, 12);
+  if (preamble.toString() !== MAGIC) {
+    throw new Error('Invalid proxy protocol preamble');
+  }
+
+  const famProt = buffer.readUInt8(13);
+  fields.length = buffer.readUInt16BE(14);
+
+  fields.family = (famProt & 0xf0) >> 4;
+  fields.protocol = famProt & 0x0f;
+
+  return fields;
+}
+
+function createParser(socket, connected, headerError) {
+    var buffer = '';
+    var header = null;
+
+    return function () {
+        var char;
+
+        try {
+            while (true) {
+                char = socket.read(1);
+                if (char === null) {
+                    return;
+                }
+                buffer += char.toString('binary');
+                if (header === null && buffer.length === 16) {
+                    header = parseProxyHeader(Buffer.from(buffer, 'binary'));
+                    buffer = '';
+                } else if (header && buffer.length === header.length) {
+                    break;
+                }
+            }
+            connected(parseProxyData(header, Buffer.from(buffer, 'binary')));
+        } catch (e) {
+            headerError(e);
+        }
+    }
+}
+
+module.exports = createParser;

--- a/lib/server/header/proxy-v2.js
+++ b/lib/server/header/proxy-v2.js
@@ -50,7 +50,7 @@ function parseTLV(buffer, offset) {
   offset += 2;
   const value = buffer.subarray(offset, offset + length).toString();
   const typeName = TLV_TYPES[type];
-  return { type: typeName, length: length + 2, value };
+  return { type: typeName, length: length + 3, value };
 }
 
 function parseProxyData(header, buffer) {
@@ -75,7 +75,7 @@ function parseProxyData(header, buffer) {
     offset += 2;
   }
 
-  while (offset < header.length - 1) {
+  while (offset < header.length) {
     const record = parseTLV(buffer, offset);
     fields.tlv.push(record);
     offset += record.length;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -22,6 +22,7 @@ var formats = {
     'default': header.proxiedSocket,
     'proxied-socket': header.proxiedSocket,
     'haproxy': header.haproxy,
+    'proxy-v2': header.proxyV2,
 };
 
 function wrap(server, options) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -22,7 +22,7 @@ var formats = {
     'default': header.proxiedSocket,
     'proxied-socket': header.proxiedSocket,
     'haproxy': header.haproxy,
-    'proxy-v2': header.proxyV2,
+    'haproxy-v2': header.haproxyV2,
 };
 
 function wrap(server, options) {

--- a/test/header/haproxy-v2.js
+++ b/test/header/haproxy-v2.js
@@ -10,7 +10,7 @@
 
 var streams = require('memory-streams'),
     assert = require('assert'),
-    createParser = require('../../lib/server/header/proxy-v2'),
+    createParser = require('../../lib/server/header/haproxy-v2'),
     sinon = require('sinon');
 
 const PROXY_V2_HEADER = '0d0a0d0a000d0a515549540a21110021'

--- a/test/header/proxied-socket.js
+++ b/test/header/proxied-socket.js
@@ -13,7 +13,7 @@ var streams = require('memory-streams'),
     createParser = require('../../lib/server/header/proxied-socket'),
     sinon = require('sinon');
 
-describe('Client', function () {
+describe('Client: proxied-socket', function () {
     it('should be a function', function () {
         assert.equal(typeof createParser, 'function');
     });

--- a/test/header/proxy-v2.js
+++ b/test/header/proxy-v2.js
@@ -10,10 +10,15 @@
 
 var streams = require('memory-streams'),
     assert = require('assert'),
-    createParser = require('../../lib/server/header/haproxy'),
+    createParser = require('../../lib/server/header/proxy-v2'),
     sinon = require('sinon');
 
-describe('Client: haproxy', function () {
+const PROXY_V2_HEADER = '0d0a0d0a000d0a515549540a21110021'
+const PROXY_V2_IPV6_HEADER = '0d0a0d0a000d0a515549540a21220039'
+const PROXY_V2_DATA = 'ac190001ac190003c200276805001262697374726f322e6661726c65792e6f7267'
+const PROXY_V2_IPV6_DATA = 'ac190001ac190001ac190001ac190001ac190003ac190003ac190003ac190003c200276805001262697374726f322e6661726c65792e6f7267'
+
+describe('Client: proxy_v2', function () {
     it('should be a function', function () {
         assert.equal(typeof createParser, 'function');
     });
@@ -25,7 +30,8 @@ describe('Client: haproxy', function () {
         assert.equal(typeof parser, 'function');
     });
     it('should reject invalid headers preamble', function () {
-        var socket = new streams.ReadableStream(new Buffer('FOOBAR TCP4 1.2.3.4 5.6.7.8 100 200\n')),
+        var invalid = '00' + PROXY_V2_HEADER.substring(0, 30);
+        var socket = new streams.ReadableStream(Buffer.from(invalid, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError);
@@ -36,7 +42,9 @@ describe('Client: haproxy', function () {
         assert.ok(onHeaderError.calledOnce);
     });
     it('should reject invalid proto', function () {
-        var socket = new streams.ReadableStream(new Buffer('PROXY FOOBAR 1.2.3.4 5.6.7.8 100 200\n')),
+        // protocol is lower nibble of 0x0d byte.
+        var invalid = PROXY_V2_HEADER.substring(0, 11) + 'aa' + PROXY_V2_HEADER.substring(13);
+        var socket = new streams.ReadableStream(Buffer.from(invalid, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError);
@@ -47,7 +55,7 @@ describe('Client: haproxy', function () {
         assert.ok(onHeaderError.calledOnce);
     });
     it('should parse address (IPv4)', function () {
-        var socket = new streams.ReadableStream(new Buffer('PROXY TCP4 1.2.3.4 5.6.7.8 100 200\n')),
+        var socket = new streams.ReadableStream(Buffer.from(PROXY_V2_HEADER + PROXY_V2_DATA, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError),
@@ -60,13 +68,15 @@ describe('Client: haproxy', function () {
         assert.ok(onConnection.calledWith(sinon.match.object));
         proxy = onConnection.getCall(0).args[0];
         assert.equal(proxy.remoteFamily, 'IPv4');
-        assert.equal(proxy.remoteAddress, '1.2.3.4');
-        assert.equal(proxy.remotePort, 100);
-        assert.equal(proxy.localAddress, '5.6.7.8');
-        assert.equal(proxy.localPort, 200);
+        assert.equal(proxy.remoteAddress, '172.25.0.1');
+        assert.equal(proxy.remotePort, 49664);
+        assert.equal(proxy.localAddress, '172.25.0.3');
+        assert.equal(proxy.localPort, 10088);
+        assert.equal(proxy.tlv[0].type, 'UNIQUE_ID')
+        assert.equal(proxy.tlv[0].value, 'bistro2.farley.org')        
     });
     it('should parse address (IPv6)', function () {
-        var socket = new streams.ReadableStream(new Buffer('PROXY TCP6 1:203:405:607:809:a0b:c0d:e0f 1213:1415:1617:1819:1a1b:1c1d:1e1f:2021 101 201\n')),
+        var socket = new streams.ReadableStream(Buffer.from(PROXY_V2_IPV6_HEADER + PROXY_V2_IPV6_DATA, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError),
@@ -79,20 +89,22 @@ describe('Client: haproxy', function () {
         assert.ok(onConnection.calledWith(sinon.match.object));
         proxy = onConnection.getCall(0).args[0];
         assert.equal(proxy.remoteFamily, 'IPv6');
-        assert.equal(proxy.remoteAddress, '1:203:405:607:809:a0b:c0d:e0f');
-        assert.equal(proxy.remotePort, 101);
-        assert.equal(proxy.localAddress, '1213:1415:1617:1819:1a1b:1c1d:1e1f:2021');
-        assert.equal(proxy.localPort, 201);
+        assert.equal(proxy.remoteAddress, 'ac19:1:ac19:1:ac19:1:ac19:1');
+        assert.equal(proxy.remotePort, 49664);
+        assert.equal(proxy.localAddress, 'ac19:3:ac19:3:ac19:3:ac19:3');
+        assert.equal(proxy.localPort, 10088);
+        assert.equal(proxy.tlv[0].type, 'UNIQUE_ID')
+        assert.equal(proxy.tlv[0].value, 'bistro2.farley.org')        
     });
     it('should parse address (IPv4 splitted)', function () {
-        var socket = new streams.ReadableStream(new Buffer('PROX')),
+        var socket = new streams.ReadableStream(Buffer.from(PROXY_V2_HEADER, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError),
             proxy;
 
         parser.call(socket);
-        socket.append('Y TCP4 1.2.3.4 5.6.7.8 100 200\n');
+        socket.append(Buffer.from(PROXY_V2_DATA, 'hex'));
         parser.call(socket);
 
         assert.ok(onConnection.calledOnce);
@@ -100,20 +112,22 @@ describe('Client: haproxy', function () {
         assert.ok(onConnection.calledWith(sinon.match.object));
         proxy = onConnection.getCall(0).args[0];
         assert.equal(proxy.remoteFamily, 'IPv4');
-        assert.equal(proxy.remoteAddress, '1.2.3.4');
-        assert.equal(proxy.remotePort, 100);
-        assert.equal(proxy.localAddress, '5.6.7.8');
-        assert.equal(proxy.localPort, 200);
+        assert.equal(proxy.remoteAddress, '172.25.0.1');
+        assert.equal(proxy.remotePort, 49664);
+        assert.equal(proxy.localAddress, '172.25.0.3');
+        assert.equal(proxy.localPort, 10088);
+        assert.equal(proxy.tlv[0].type, 'UNIQUE_ID')
+        assert.equal(proxy.tlv[0].value, 'bistro2.farley.org')        
     });
-    it('should parse address (IPv6)', function () {
-        var socket = new streams.ReadableStream(new Buffer('PROXY TCP6 1:203:405:607:809:a0b:c0d:e0f')),
+    it('should parse address (IPv6 splitted)', function () {
+        var socket = new streams.ReadableStream(Buffer.from(PROXY_V2_IPV6_HEADER, 'hex')),
             onConnection = sinon.spy(),
             onHeaderError = sinon.spy(),
             parser = createParser(socket, onConnection, onHeaderError),
             proxy;
 
         parser.call(socket);
-        socket.append(' 1213:1415:1617:1819:1a1b:1c1d:1e1f:2021 101 201\n');
+        socket.append(Buffer.from(PROXY_V2_IPV6_DATA, 'hex'));
         parser.call(socket);
 
         assert.ok(onConnection.calledOnce);
@@ -121,9 +135,11 @@ describe('Client: haproxy', function () {
         assert.ok(onConnection.calledWith(sinon.match.object));
         proxy = onConnection.getCall(0).args[0];
         assert.equal(proxy.remoteFamily, 'IPv6');
-        assert.equal(proxy.remoteAddress, '1:203:405:607:809:a0b:c0d:e0f');
-        assert.equal(proxy.remotePort, 101);
-        assert.equal(proxy.localAddress, '1213:1415:1617:1819:1a1b:1c1d:1e1f:2021');
-        assert.equal(proxy.localPort, 201);
+        assert.equal(proxy.remoteAddress, 'ac19:1:ac19:1:ac19:1:ac19:1');
+        assert.equal(proxy.remotePort, 49664);
+        assert.equal(proxy.localAddress, 'ac19:3:ac19:3:ac19:3:ac19:3');
+        assert.equal(proxy.localPort, 10088);
+        assert.equal(proxy.tlv[0].type, 'UNIQUE_ID')
+        assert.equal(proxy.tlv[0].value, 'bistro2.farley.org')        
     });
 });


### PR DESCRIPTION
Hey Carlo, I am back again with another addition. This adds support for the haproxy proxy protocol version 2. This version uses a binary format and can include additional fields. Additional fields are TLV (type, length, value) records that are optional. The project that I use `proxied-socket` in requires this new format. The proxy protocol is documented at the link below.

https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

I included tests which mirror the existing tests for the haproxy and proxied-socket formats. I used an actual header from haproxy in the tests.